### PR TITLE
feat: fetch images when user stops typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosee-application",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/views/Grid.vue
+++ b/src/views/Grid.vue
@@ -6,6 +6,7 @@ export default {
     return {
       images: Array,
       queryString: '',
+      timer: undefined,
     };
   },
   components: { GridItem },
@@ -18,7 +19,11 @@ export default {
       }
       var queryJSON = JSON.stringify(query);
 
-      this.getImages(queryJSON);
+      clearTimeout(this.timer);
+
+      this.timer = setTimeout(() => {
+        this.getImages(queryJSON);
+      }, 750);
     },
     getImages(query) {
       var overlay = document.getElementsByClassName('loading-container')[0];
@@ -58,7 +63,7 @@ export default {
       name="filter"
       placeholder="Type the tags to filter for"
       v-model="queryString"
-      v-on:keyup.enter="filter"
+      v-on:keyup="filter"
     />
 
     <a href="/upload">Upload File</a>


### PR DESCRIPTION
### What is changed?
Once the user stops typing, the filtered images are fetched again on the image grid page.

### Why did you do it?
To make the filter experience more intuitive and deliver specified images more quickly.

### How did you implement it?
`filter()` is now called every time the user releases a key on the keyboard (instead of releasing the enter key). In addition, every event trigger updates the new `timer` property by setting a timeout 750 ms after the event was triggered. If the event is not triggered again within this timer, `getImages()` is called. If the event is triggered again before the specified 750 ms timer is done, the timer is reset by `clearTimeout(timer)`.

### Test Coverage
No tests have been included. I tested the feature in the dev environment manually.

### Screenshots (optional)
None provided

### Anything else?
For the timer, I selected 750 ms because the average user writes at least one word at this time. If the user has not entered a new letter during this time, he is either finished typing or thinking of additional input. If the new images are already loaded, it helps the user filter the elements further.