### PR TITLE
feat: visual feedback when user hovers over gallery item

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -14,7 +14,9 @@ export default {
 
 <template>
   <a class="image-grid-item" :href="id">
-    <img :src="image" :alt="name" />
+    <div class="image">
+      <img :src="image" :alt="name" />
+    </div>
     <h2>{{ name }}</h2>
     <div class="image-tags" v-if="tags">
       <Tag v-for="tag in tags" :key="tag" :label="tag" />
@@ -35,14 +37,22 @@ a.image-grid-item {
   color: black;
 }
 
-a.image-grid-item > img {
+a.image-grid-item > .image {
   width: 100%;
   aspect-ratio: 16/9;
   border-radius: 5px;
-  transition: 500ms;
+  background-color: #d9d9d9;
+  overflow: hidden;
+}
+a.image-grid-item > .image > img {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   object-position: center;
-  background-color: #d9d9d9;
+  transition: 750ms;
+}
+a.image-grid-item:hover > .image > img {
+  scale: 1.05;
 }
 
 a.image-grid-item > h2 {

--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -49,7 +49,7 @@ a.image-grid-item > .image > img {
   height: 100%;
   object-fit: cover;
   object-position: center;
-  transition: 750ms;
+  transition: 500ms;
 }
 a.image-grid-item:hover > .image > img {
   scale: 1.05;


### PR DESCRIPTION
### What is changed?
When a user is hovering over an image on the gallery page, the user gets immediate visual feedback when entering and leaving the item.

### Why did you do it?
Visual feedback to make the app more intuitive and appealing to use.

### How did you implement it?
The image is now wrapped in a `div` hiding any overflow. The `:hover` state is adding a scale effect of `1.05` to the image with a transition of `500 ms` to make the effect smooth. 

### Test Coverage
No tests included. The change was tested manually in the dev environment.

### Screenshots (optiona

https://user-images.githubusercontent.com/63814520/162986811-d15bde2a-b7fd-4a99-809e-9f12ecd44cff.mov

https://user-images.githubusercontent.com/63814520/162986850-5db89a6b-aab7-4e99-8714-413d940e0238.mov

### Anything else?
#3 
